### PR TITLE
add SecurityAuditAspect saving log info about user that rated the record

### DIFF
--- a/src/main/java/dev/steadypim/thewhitehw/homework1/UtilityStorageApp.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/UtilityStorageApp.java
@@ -2,8 +2,10 @@ package dev.steadypim.thewhitehw.homework1;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @SpringBootApplication
+@EnableAspectJAutoProxy
 public class UtilityStorageApp {
     public static void main(String[] args) {
         SpringApplication.run(UtilityStorageApp.class, args);

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/api/grade/mapper/GradeMapper.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/api/grade/mapper/GradeMapper.java
@@ -22,6 +22,7 @@ public interface GradeMapper {
     GradeDTO toDto(Grade grade);
 
     SearchGradeArgument toSearchArgument(GradeSearchCriteriaDTO argument, Pageable pageable);
+
     @Mapping(source = "resultPage.content", target = "content")
     @Mapping(source = "resultPage.totalElements", target = "totalElements")
     PageDTO<GradeDTO> toSearchResultDTO(Page<Grade> resultPage);

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/api/securityaudit/SecurityAuditController.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/api/securityaudit/SecurityAuditController.java
@@ -1,0 +1,44 @@
+package dev.steadypim.thewhitehw.homework1.api.securityaudit;
+
+import dev.steadypim.thewhitehw.homework1.api.PageDTO;
+import dev.steadypim.thewhitehw.homework1.api.securityaudit.dtos.SecurityAuditDTO;
+import dev.steadypim.thewhitehw.homework1.api.securityaudit.dtos.SecurityAuditSearchCriteriaDTO;
+import dev.steadypim.thewhitehw.homework1.api.securityaudit.mapper.SecurityAuditMapper;
+import dev.steadypim.thewhitehw.homework1.service.securityaudit.SecurityAuditService;
+import dev.steadypim.thewhitehw.homework1.service.securityaudit.argument.SearchSecurityAuditArgument;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static lombok.AccessLevel.PRIVATE;
+import static org.springframework.data.domain.Sort.Direction.ASC;
+
+@Tag(name = "Контроллер для работы с аудитом")
+@RestController
+@RequestMapping("audit")
+@RequiredArgsConstructor
+@FieldDefaults(level = PRIVATE, makeFinal = true)
+public class SecurityAuditController {
+
+    SecurityAuditService service;
+    SecurityAuditMapper mapper;
+
+    @GetMapping("search")
+    @Operation(description = "Получение постраничного списка аудита с поиском по полю info")
+    public PageDTO<SecurityAuditDTO> searchSecurityAudit(
+            @ModelAttribute SecurityAuditSearchCriteriaDTO criteriaDTO,
+            @PageableDefault(sort = "info", direction = ASC) Pageable pageable) {
+
+        SearchSecurityAuditArgument securityAuditArgument = mapper.toSearchArgument(criteriaDTO, pageable);
+
+        return mapper.toSearchResultDTO(service.searchSecurityAudit(securityAuditArgument));
+    }
+
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/api/securityaudit/dtos/SecurityAuditDTO.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/api/securityaudit/dtos/SecurityAuditDTO.java
@@ -1,0 +1,14 @@
+package dev.steadypim.thewhitehw.homework1.api.securityaudit.dtos;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+public class SecurityAuditDTO {
+    Integer gradeId;
+    String info;
+    OffsetDateTime createdAt;
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/api/securityaudit/dtos/SecurityAuditSearchCriteriaDTO.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/api/securityaudit/dtos/SecurityAuditSearchCriteriaDTO.java
@@ -1,0 +1,14 @@
+package dev.steadypim.thewhitehw.homework1.api.securityaudit.dtos;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@Setter
+@FieldDefaults(level = PRIVATE)
+public class SecurityAuditSearchCriteriaDTO {
+    String info;
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/api/securityaudit/mapper/SecurityAuditMapper.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/api/securityaudit/mapper/SecurityAuditMapper.java
@@ -1,0 +1,21 @@
+package dev.steadypim.thewhitehw.homework1.api.securityaudit.mapper;
+
+import dev.steadypim.thewhitehw.homework1.api.PageDTO;
+import dev.steadypim.thewhitehw.homework1.api.securityaudit.dtos.SecurityAuditDTO;
+import dev.steadypim.thewhitehw.homework1.api.securityaudit.dtos.SecurityAuditSearchCriteriaDTO;
+import dev.steadypim.thewhitehw.homework1.entity.SecurityAudit;
+import dev.steadypim.thewhitehw.homework1.service.securityaudit.argument.SearchSecurityAuditArgument;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+@Mapper(componentModel = SPRING)
+public interface SecurityAuditMapper {
+    SearchSecurityAuditArgument toSearchArgument(SecurityAuditSearchCriteriaDTO criteriaDTO, Pageable pageable);
+
+    @Mapping(source = "searchSecurityAudit.content", target = "content")
+    @Mapping(source = "searchSecurityAudit.totalElements", target = "totalElements")
+    PageDTO<SecurityAuditDTO> toSearchResultDTO(Page<SecurityAudit> searchSecurityAudit);
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/aspect/SecurityAuditAspect.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/aspect/SecurityAuditAspect.java
@@ -32,7 +32,6 @@ public class SecurityAuditAspect {
     public void afterCreatingGrade(Object grade) {
         if (grade instanceof Grade gradeInstance) {
             ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-            assert attributes != null;
             HttpServletRequest request = attributes.getRequest();
 
             String ipAddress = obtainIpAddress(request);

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/aspect/SecurityAuditAspect.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/aspect/SecurityAuditAspect.java
@@ -32,14 +32,20 @@ public class SecurityAuditAspect {
     public void afterCreatingGrade(Object grade) {
         if (grade instanceof Grade gradeInstance) {
             ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-            HttpServletRequest request = attributes.getRequest();
+            String info;
+            if (attributes != null) {
+                HttpServletRequest request = attributes.getRequest();
+                String ipAddress = obtainIpAddress(request);
+                String userAgent = obtainUserAgent(attributes);
+                info = "IP: " + ipAddress + "; User-Agent: " + userAgent;
 
-            String ipAddress = obtainIpAddress(request);
-            String userAgent = obtainUserAgent(attributes);
-
+            }
+            else {
+                info = "Не удалось получить";
+            }
             CreateSecurityAuditArgument auditArgument = CreateSecurityAuditArgument.builder()
                     .gradeId(gradeInstance.getId())
-                    .info("IP: " + ipAddress + "; User-Agent: " + userAgent)
+                    .info(info)
                     .createdAt(now())
                     .build();
 

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/aspect/SecurityAuditAspect.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/aspect/SecurityAuditAspect.java
@@ -1,0 +1,50 @@
+package dev.steadypim.thewhitehw.homework1.aspect;
+
+import dev.steadypim.thewhitehw.homework1.entity.Grade;
+import dev.steadypim.thewhitehw.homework1.service.securityaudit.SecurityAuditService;
+import dev.steadypim.thewhitehw.homework1.service.securityaudit.argument.CreateSecurityAuditArgument;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static dev.steadypim.thewhitehw.homework1.general.network.NetworkInfoProvider.obtainIpAddress;
+import static dev.steadypim.thewhitehw.homework1.general.network.NetworkInfoProvider.obtainUserAgent;
+import static java.time.OffsetDateTime.now;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class SecurityAuditAspect {
+
+    private final SecurityAuditService service;
+
+    @Pointcut("execution(* dev.steadypim.thewhitehw.homework1.service.grade.GradeServiceImpl.create(..))")
+    private void createGradePointcut() {
+
+    }
+
+    @AfterReturning(pointcut = "createGradePointcut()", returning = "grade")
+    public void afterCreatingGrade(Object grade) {
+        if (grade instanceof Grade gradeInstance) {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            assert attributes != null;
+            HttpServletRequest request = attributes.getRequest();
+
+            String ipAddress = obtainIpAddress(request);
+            String userAgent = obtainUserAgent(attributes);
+
+            CreateSecurityAuditArgument auditArgument = CreateSecurityAuditArgument.builder()
+                    .gradeId(gradeInstance.getId())
+                    .info("IP: " + ipAddress + "; User-Agent: " + userAgent)
+                    .createdAt(now())
+                    .build();
+
+            service.create(auditArgument);
+        }
+    }
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/entity/SecurityAudit.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/entity/SecurityAudit.java
@@ -1,0 +1,24 @@
+package dev.steadypim.thewhitehw.homework1.entity;
+
+import dev.steadypim.thewhitehw.homework1.general.entitypk.BaseEntity;
+import jakarta.persistence.Entity;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.time.OffsetDateTime;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@FieldDefaults(level = PRIVATE)
+@AllArgsConstructor
+@NoArgsConstructor
+public class SecurityAudit extends BaseEntity {
+    Integer gradeId;
+    String info;
+    OffsetDateTime createdAt;
+}
+

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/general/network/NetworkInfoProvider.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/general/network/NetworkInfoProvider.java
@@ -1,0 +1,87 @@
+package dev.steadypim.thewhitehw.homework1.general.network;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public final class NetworkInfoProvider {
+
+    private NetworkInfoProvider() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    private static final String[] HEADERS_TO_TRY = {
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED",
+            "HTTP_X_CLUSTER_CLIENT_IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_FORWARDED_FOR",
+            "HTTP_FORWARDED",
+            "HTTP_VIA",
+            "REMOTE_ADDR"
+    };
+
+    public static String obtainIpAddress(HttpServletRequest request) {
+        String ipAddress = extractIpAddressFromHeaders(request);
+
+        if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+            ipAddress = extractIpAddressFromRemoteAddress(request);
+        }
+
+        if (ipAddress != null && ipAddress.length() > 15 && ipAddress.contains(",")) {
+            ipAddress = ipAddress.substring(0, ipAddress.indexOf(","));
+        }
+
+        return ipAddress;
+    }
+
+    private static String extractIpAddressFromHeaders(HttpServletRequest request) {
+        for (String header : HEADERS_TO_TRY) {
+            String ipAddress = request.getHeader(header);
+            if (isValidIpAddress(ipAddress)) {
+                return ipAddress;
+            }
+        }
+        return null;
+    }
+
+    private static String extractIpAddressFromRemoteAddress(HttpServletRequest request) {
+        String ipAddress = request.getRemoteAddr();
+        if (isLocalhostIpAddress(ipAddress)) {
+            InetAddress inet = getLocalHostInetAddress();
+            ipAddress = (inet != null) ? inet.getHostAddress() : null;
+        }
+        return ipAddress;
+    }
+
+    private static boolean isValidIpAddress(String ipAddress) {
+        return ipAddress != null && !ipAddress.isEmpty() && !"unknown".equalsIgnoreCase(ipAddress);
+    }
+
+    private static boolean isLocalhostIpAddress(String ipAddress) {
+        return ipAddress.equals("127.0.0.1") || ipAddress.equals("0:0:0:0:0:0:0:1");
+    }
+
+    private static InetAddress getLocalHostInetAddress() {
+        try {
+            return InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+
+    public static String obtainUserAgent(ServletRequestAttributes attributes) {
+
+        HttpServletRequest request = attributes.getRequest();
+
+        return request.getHeader("User-Agent");
+    }
+
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/repository/securityaudit/SecurityAuditRepository.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/repository/securityaudit/SecurityAuditRepository.java
@@ -1,0 +1,14 @@
+package dev.steadypim.thewhitehw.homework1.repository.securityaudit;
+
+import dev.steadypim.thewhitehw.homework1.entity.SecurityAudit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.stereotype.Repository;
+
+
+/**
+ * Репозиторий для работы с данными в SecurityAudit
+ */
+@Repository
+public interface SecurityAuditRepository extends JpaRepository<SecurityAudit, Integer>, QuerydslPredicateExecutor<SecurityAudit> {
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/service/securityaudit/SecurityAuditService.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/service/securityaudit/SecurityAuditService.java
@@ -1,0 +1,12 @@
+package dev.steadypim.thewhitehw.homework1.service.securityaudit;
+
+import dev.steadypim.thewhitehw.homework1.entity.SecurityAudit;
+import dev.steadypim.thewhitehw.homework1.service.securityaudit.argument.CreateSecurityAuditArgument;
+import dev.steadypim.thewhitehw.homework1.service.securityaudit.argument.SearchSecurityAuditArgument;
+import org.springframework.data.domain.Page;
+
+public interface SecurityAuditService {
+    Page<SecurityAudit> searchSecurityAudit(SearchSecurityAuditArgument argument);
+
+    SecurityAudit create(CreateSecurityAuditArgument argument);
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/service/securityaudit/SecurityAuditServiceImpl.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/service/securityaudit/SecurityAuditServiceImpl.java
@@ -1,0 +1,41 @@
+package dev.steadypim.thewhitehw.homework1.service.securityaudit;
+
+import com.querydsl.core.BooleanBuilder;
+import dev.steadypim.thewhitehw.homework1.entity.QSecurityAudit;
+import dev.steadypim.thewhitehw.homework1.entity.SecurityAudit;
+import dev.steadypim.thewhitehw.homework1.repository.securityaudit.SecurityAuditRepository;
+import dev.steadypim.thewhitehw.homework1.service.securityaudit.argument.CreateSecurityAuditArgument;
+import dev.steadypim.thewhitehw.homework1.service.securityaudit.argument.SearchSecurityAuditArgument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SecurityAuditServiceImpl implements SecurityAuditService{
+
+    private final SecurityAuditRepository repository;
+    @Override
+    @Transactional(readOnly = true)
+    public Page<SecurityAudit> searchSecurityAudit(SearchSecurityAuditArgument argument) {
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        if(argument.getInfo() != null){
+            predicate.and(QSecurityAudit.securityAudit.info.eq(argument.getInfo()));
+        }
+        return repository.findAll(predicate, argument.getPageable());
+    }
+
+    @Override
+    @Transactional
+    public SecurityAudit create(CreateSecurityAuditArgument argument) {
+        SecurityAudit audit = SecurityAudit.builder()
+                .gradeId(argument.getGradeId())
+                .info(argument.getInfo())
+                .createdAt(argument.getCreatedAt())
+                .build();
+
+        return repository.save(audit);
+    }
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/service/securityaudit/argument/CreateSecurityAuditArgument.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/service/securityaudit/argument/CreateSecurityAuditArgument.java
@@ -1,0 +1,18 @@
+package dev.steadypim.thewhitehw.homework1.service.securityaudit.argument;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import java.time.OffsetDateTime;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Data
+@Builder
+@FieldDefaults(level = PRIVATE)
+public class CreateSecurityAuditArgument {
+    Integer gradeId;
+    String info;
+    OffsetDateTime createdAt;
+}

--- a/src/main/java/dev/steadypim/thewhitehw/homework1/service/securityaudit/argument/SearchSecurityAuditArgument.java
+++ b/src/main/java/dev/steadypim/thewhitehw/homework1/service/securityaudit/argument/SearchSecurityAuditArgument.java
@@ -1,0 +1,16 @@
+package dev.steadypim.thewhitehw.homework1.service.securityaudit.argument;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.domain.Pageable;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@Builder
+@FieldDefaults(level = PRIVATE)
+public class SearchSecurityAuditArgument {
+    String info;
+    Pageable pageable;
+}

--- a/src/test/resources/datasets/controller/grade/grade_create__expected.json
+++ b/src/test/resources/datasets/controller/grade/grade_create__expected.json
@@ -33,5 +33,13 @@
       "utility_storage_id": 1,
       "link": "https://example.com/3"
     }
+  ],
+  "security_audit": [
+    {
+      "id": 1,
+      "grade_id": 2,
+      "created_at": "regex:.+",
+      "info": "regex:IP:\\s*((?:\\d{1,3}\\.){3}\\d{1,3}|[a-fA-F0-9:]+);\\s*User-Agent:\\s*.+"
+    }
   ]
 }


### PR DESCRIPTION
Не могу разобраться работает ли пагинация.
Условно в БД есть две записи:
{
            "gradeId": 22,
            "info": "IP: 0:0:0:0:0:0:0:1; User-Agent: PostmanRuntime/7.35.0",
            "createdAt": "2023-12-11T07:54:00.688123Z"
        },
        {
            "gradeId": 26,
            "info": "IP: 192.168.56.1; User-Agent: PostmanRuntime/7.35.0",
            "createdAt": "2023-12-11T08:37:34.776754Z"
        },
Отправляю запрос такого рода localhost:8090/audit/search?page=0&size=10&info=IP: 192.168.56.1; User-Agent: PostmanRuntime/7.35.0,desc
получаю 
{
    "content": null,
    "totalElements": 0
}
Не пойму, то ли я накосячил с кодом, то ли запрос не могу правильно отправить, пробовал и в кавычках. Пагинация сделана по примеру прошлых, там все работает правильно.

Аспект работает.